### PR TITLE
Create new OSE project in Windows script

### DIFF
--- a/init.bat
+++ b/init.bat
@@ -58,6 +58,11 @@ if not "%ERRORLEVEL%" == "0" (
 )
 
 echo.
+echo Creating a new project...
+echo.
+call oc new-project rhcs-bpms-install-demo
+
+echo.
 echo Setting up a new build...
 echo.
 call oc new-build "jbossdemocentral/developer" --name=rhcs-bpms-install-demo --binary=true


### PR DESCRIPTION
Added omitted project creation step to prevent bpms resources from being created in the default project
