### PR TITLE
Added support for remote cloning of repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,7 +46,7 @@ RUN /opt/jboss/fix-permissions $BPMS_HOME/standalone/configuration/standalone.xm
 USER 1000
 
 # Expose Ports
-EXPOSE 9990 9999 8080
+EXPOSE 9990 9999 8080 9418 8001
 
 # Run BPMS
 CMD ["/opt/jboss/bpms/jboss-eap-7.0/bin/standalone.sh","-c","standalone.xml","-b", "0.0.0.0","-bmanagement","0.0.0.0"]

--- a/init.sh
+++ b/init.sh
@@ -187,7 +187,7 @@ fi
 echo
 echo "Creating an externally facing route by exposing a service..."
 echo
-oc expose service rhcs-bpms-install-demo --hostname=rhcs-bpms-install-demo.$HOST_IP.xip.io
+oc expose service rhcs-bpms-install-demo --port=8080 --hostname=rhcs-bpms-install-demo.$HOST_IP.xip.io
 
 if [ $? -ne 0 ]; then
 	echo


### PR DESCRIPTION
Expose additional ports to enable remote git cloning from developer machine

To clone a repository in the running container, the following actions would need to occur from a developer's machine.

1. Execute port forwarding through the OpenShift CLI to port 9418

```
oc port-forward $(oc get pod -l=deploymentconfig=rhcs-bpms-install-demo --template='{{ range .items }} {{ .metadata.name }} {{ end }}') 9418:9418
```

This will open a tunnel between the developer's machine and the pod through the OpenShift API pod proxy. The command window will block while the session is open

2. Clone the repository

In another window, clone the remote repository

```
git clone git://localhost:9418/BackOffice
```